### PR TITLE
[Issue7] 이미지 돌아가는 이슈 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     implementation(libs.google.accompanist)
     implementation(libs.okhttp3)
     implementation(libs.okhttp3.interceptor)
+    implementation(libs.androidx.exifinterface)
     ksp(libs.dagger.hilt.compiler)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ coil = "2.4.0"
 camera = "1.2.0"
 accompanist = "0.35.0-alpha"
 okhttp3 = "4.11.0"
+exifinterface = "1.3.6"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -53,6 +54,7 @@ androidx-camera-extensions = { module = "androidx.camera:camera-extensions", ver
 google-accompanist = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 okhttp3-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp3" }
+androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exifinterface" }
 
 
 [plugins]


### PR DESCRIPTION
### 상황

아래와 같이 홈화면에서 이미지를 봤을 때 돌아가있는 이슈 수정

<img width="400" height="300" alt="스크린샷 2025-08-12 오후 7 39 10" src="https://github.com/user-attachments/assets/f2dc4ee2-9593-43d3-b1a0-d311bd86e1cc" />


### 과정
카메라가 저장할 때 EXIF 메타데이터에 회전 정보만 기록하고, 실제 비트맵 픽셀은 회전시키지 않았기 때문 -> 이미지를 decode하기 전에 EXIF 메타데이터를 읽고, 그에 맞게 비트맵을 회전시켜 이미지가 정방향으로 보이도록 수정
<img width="400" height="300" alt="스크린샷 2025-08-12 오후 7 41 12" src="https://github.com/user-attachments/assets/95a478c9-67c1-4018-88d9-684b11eaff6d" />
